### PR TITLE
Adds uniqueness in the default AP name

### DIFF
--- a/ESP8266Basic/WIFI_stuff.ino
+++ b/ESP8266Basic/WIFI_stuff.ino
@@ -84,7 +84,7 @@ void CreateAP(String NetworkName, String NetworkPassword)
 
     if (NetworkName == "")
     {
-      NetworkName = "ESP";
+      NetworkName = "ESP" + WiFi.softAPmacAddress();
       NetworkPassword = "";
     }
   }


### PR DESCRIPTION
Hi, I'd like to propose a small enhancement to your awesome library.
When I had students working on ESP8266 using the Basic firmware they had trouble identifying which AP correspond to which hardware, this because they are all named "ESP" by default.

The enhancement I suggest is using either the MAC address or any unique identifier (MAC address sounds sound) to build the default AP name. Also this name needs to be output via the Serial in order to know which AP should I connect to.
